### PR TITLE
Fix for auth initial state

### DIFF
--- a/react/src/store/auth/index.js
+++ b/react/src/store/auth/index.js
@@ -55,12 +55,14 @@ let mantle = {}
 let address = ''
 let publicKey = ''
 let mnemonic = localStorage.getAuth('mnemonic', true) || ''
+let authenticated = false
 if (mnemonic) {
   try {
     mantle = new Mantle()
     mantle.loadMnemonic(mnemonic)
     address = mantle.address
     publicKey = mantle.getPublicKey('hex0x')
+    authenticated = true
   } catch (error) {
     console.log(error)
     mnemonic = ''
@@ -72,7 +74,7 @@ if (mnemonic) {
 
 // Reducer
 const initialState = {
-  authenticated: !!localStorage.getAuth('mnemonic', true),
+  authenticated,
   mantle,
   mnemonic,
   address,


### PR DESCRIPTION
**Description**

Hotfix for the initial state

**Work Done**

In order to prevent `fetch` actions for retrieving notes before `mantle` is initialised, thus resulting in notes that cannot be decrypted, the initial state will attempt to initialise `mantle`.