### PR TITLE
Add logspout server to post logs to papertrail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,15 @@ services:
     image: appliedblockchain/mantle-parity3:latest
     volumes:
     - parity3_data:/parity/data
+  logspout:
+    image: gliderlabs/logspout
+    deploy:
+      mode: global
+    command: syslog+tls://logs7.papertrailapp.com:43764
+    volumes:
+      - type: bind
+        target: /var/run/docker.sock
+        source: /var/run/docker.sock
 
 volumes:
   parity1_data:


### PR DESCRIPTION
[logspout](https://hub.docker.com/r/gliderlabs/logspout/) is added to post all containers logs to paper trail. 

<img width="1705" alt="screenshot 2018-12-05 at 12 04 26" src="https://user-images.githubusercontent.com/9810337/49512492-0354df00-f886-11e8-9475-fe17d57d0af7.png">

Required to be tested if it works on docker swarm.
https://help.papertrailapp.com/kb/configuration/configuring-centralized-logging-from-docker#logspout
